### PR TITLE
Fix: HTC eye & face Tracking mapping

### DIFF
--- a/ALVRModule/HtcFaceTracking.cs
+++ b/ALVRModule/HtcFaceTracking.cs
@@ -77,8 +77,8 @@ namespace ALVRModule
         {
             p.Read((int)EyesMax);
 
-            eye.Right.Openness = 1.0f - Math.Clamp(p[RightBlink] + p[RightBlink] * p[RightSqueeze], 0.0f, 1.0f);
-            eye.Left.Openness = 1.0f - Math.Clamp(p[LeftBlink] + p[LeftBlink] * p[LeftSqueeze], 0.0f, 1.0f);
+            eye.Right.Openness = 1.0f - p[RightBlink];
+            eye.Left.Openness = 1.0f - p[LeftBlink];
 
             eye.Right.Gaze.x = p[RightOut] - p[RightIn];
             eye.Right.Gaze.y = p[RightUp] - p[RightDown];
@@ -116,7 +116,7 @@ namespace ALVRModule
             
             #region Direct Jaw
 
-            w[U.JawOpen] = p[JawOpen] + p[MouthApeShape];
+            w[U.JawOpen] = p[JawOpen];
             w[U.JawLeft] = p[JawLeft];
             w[U.JawRight] = p[JawRight];
             w[U.JawForward] = p[JawForward];
@@ -126,13 +126,13 @@ namespace ALVRModule
 
             #region Direct Mouth and Lip
 
-            w[MouthUpperUpRight] = p[MouthUpperRight] - p[MouthUpperOverturn];
+            w[MouthUpperUpRight] = p[MouthUpperUpright];
             w[MouthUpperDeepenRight] = p[MouthUpperRight] - p[MouthUpperOverturn];
-            w[MouthUpperUpLeft] = p[MouthUpperLeft] - p[MouthUpperOverturn];
+            w[MouthUpperUpLeft] = p[MouthUpperUpleft];
             w[MouthUpperDeepenLeft] = p[MouthUpperLeft] - p[MouthUpperOverturn];
 
-            w[MouthLowerDownLeft] = p[MouthLowerLeft] - p[MouthLowerOverturn];
-            w[MouthLowerDownRight] = p[MouthLowerRight] - p[MouthLowerOverturn];
+            w[MouthLowerDownLeft] = p[MouthLowerDownleft];
+            w[MouthLowerDownRight] = p[MouthLowerDownright];
 
             w[LipPuckerUpperLeft] = p[MouthPout];
             w[LipPuckerLowerLeft] = p[MouthPout];

--- a/metadata.json
+++ b/metadata.json
@@ -1,10 +1,10 @@
 {
     "ModuleId": "699750bf-e217-4bd8-8039-3d5f97ee80ba",
-    "AuthorName": "zmerp, curoviyxru",
+    "AuthorName": "zmerp, curoviyxru, AzumiYura",
     "DllFileName": "ALVRModule.dll",
     "Downloads": 0,
-    "DownloadUrl": "https://github.com/alvr-org/VRCFT-ALVR/releases/download/v1.3.0/ALVRModule.zip",
-    "LastUpdated": "2024-01-09T18:07:55Z",
+    "DownloadUrl": "https://github.com/alvr-org/VRCFT-ALVR/releases/download/v1.3.1/ALVRModule.zip",
+    "LastUpdated": "2025-05-09T03:36:40Z",
     "ModuleDescription": "VRCFaceTracking module for ALVR support",
     "ModuleName": "ALVR Module",
     "ModulePageUrl": "https://github.com/alvr-org/VRCFT-ALVR",
@@ -12,5 +12,5 @@
     "Ratings": 0,
     "RatingSum": 0,
     "UsageInstructions": "Set `Eye and face tracking` to `VRCFaceTracking`. Reconnect the client if necessary.",
-    "Version": "1.3.0"
+    "Version": "1.3.1"
 }


### PR DESCRIPTION
Fixes to HTC Eye & Face Tracking Calculations/Mapping
 ( [issue#7](https://github.com/alvr-org/VRCFT-ALVR/issues/7) )

Eye Tracking
- Fixed calculation for blinking motion
(modified to reference only the original Blink value to make it easier to obtain intermediate values)

Face Tracking
- Fixed calculation for "JawOpen" (mouth opening motion)
- Fixed parameter mapping for "MouthUpperUpLeft/Right" (motion showing upper teeth)
- Fixed parameter mapping for "MouthLowerDownLeft/Right" (motion showing lower teeth)

ex) Vive Focus Vision HMD was used for motion testing.