### PR TITLE
feat: seperate pico into phoenix, add support for seperate eye movement and eye dilation.

### DIFF
--- a/ALVRModule/ALVRModule.cs
+++ b/ALVRModule/ALVRModule.cs
@@ -22,6 +22,8 @@ namespace ALVRModule
             ["FaceFb\0\0"] = FbFaceTracking.SetFace1FbParams,
             ["Face2Fb\0"] = FbFaceTracking.SetFace2FbParams,
             ["FacePico"] = PicoFaceTracking.SetFacePicoParams,
+            ["FacePhnx"] = PicoFaceTracking.SetFacePicoParams,
+            ["EyesPhnx"] = PhoenixEyeTracking.SetEyesPhoenixParams,
             ["EyesHtc\0"] = HtcFaceTracking.SetEyesHtcParams,
             ["LipHtc\0\0"] = HtcFaceTracking.SetLipHtcParams,
         };
@@ -51,6 +53,8 @@ namespace ALVRModule
             }
             catch (Exception)
             {
+                // This branch is non-blocking, so we let the thread sleep.
+                Thread.Sleep(100);
                 return;
             }
 

--- a/ALVRModule/FloatParams.cs
+++ b/ALVRModule/FloatParams.cs
@@ -12,11 +12,18 @@ namespace ALVRModule
             get; private set;
         }
 
-        public float this[Enum index]
+        public float this[object index]
         {
             get
             {
                 return Params?[Convert.ToInt32(index)] ?? 0;
+            }
+            set
+            {
+                if (Params == null)
+                    return;
+
+                Params[Convert.ToInt32(index)] = value;
             }
         }
 

--- a/ALVRModule/PhoenixEyeTracking.cs
+++ b/ALVRModule/PhoenixEyeTracking.cs
@@ -1,0 +1,53 @@
+﻿using VRCFaceTracking.Core.Params.Data;
+
+namespace ALVRModule
+{
+    using static PhoenixEyeParams;
+    enum PhoenixEyeParams
+    {
+        LeftEyeGazeVectorX,
+        LeftEyeGazeVectorY,
+        RightEyeGazeVectorX,
+        RightEyeGazeVectorY,
+        LeftEyeOpenness,
+        RightEyeOpenness,
+        LeftEyePupilDilation,
+        RightEyePupilDilation
+    }
+
+    public class PhoenixEyeTracking
+    {
+        /// <summary>
+        /// Below this threshold the pupil dilation will pause.
+        /// </summary>
+        const float EYE_PUPIL_DILATION_EYE_OPENNESS_THRESHOLD = 0.8f;
+        public static void SetEyesPhoenixParams(FloatParams p, FloatWeightParams w, UnifiedEyeData eye)
+        {
+            p.Read(8);
+
+            #region LEFT EYE
+            eye.Left.Gaze.x = p[LeftEyeGazeVectorX];
+            eye.Left.Gaze.y = p[LeftEyeGazeVectorY];
+            eye.Left.Openness = p[LeftEyeOpenness];
+
+            if (p[LeftEyePupilDilation] == 0)
+                p[LeftEyePupilDilation] = 50f;
+
+            if (p[LeftEyeOpenness] > EYE_PUPIL_DILATION_EYE_OPENNESS_THRESHOLD)
+                eye.Left.PupilDiameter_MM = p[LeftEyePupilDilation] / 10;
+            #endregion
+
+            #region RIGHT EYE
+            eye.Right.Gaze.x = p[RightEyeGazeVectorX];
+            eye.Right.Gaze.y = p[RightEyeGazeVectorY];
+            eye.Right.Openness = p[RightEyeOpenness];
+
+            if (p[RightEyePupilDilation] == 0)
+                p[RightEyePupilDilation] = 50f;
+
+            if (p[RightEyeOpenness] > EYE_PUPIL_DILATION_EYE_OPENNESS_THRESHOLD)
+                eye.Right.PupilDiameter_MM = p[RightEyePupilDilation] / 10;
+            #endregion
+        }
+    }
+}

--- a/ALVRModule/PicoFaceTracking.cs
+++ b/ALVRModule/PicoFaceTracking.cs
@@ -86,10 +86,7 @@ namespace ALVRModule
     {
         public static void SetFacePicoParams(FloatParams p, FloatWeightParams w, UnifiedEyeData eye)
         {
-            p.Read((int)FaceMax);
-
-            eye.Right.Openness = 1.0f - Math.Clamp(p[EyeBlinkR] + p[EyeBlinkR] * p[EyeSquintR], 0.0f, 1.0f);
-            eye.Left.Openness = 1.0f - Math.Clamp(p[EyeBlinkL] + p[EyeBlinkL] * p[EyeSquintL], 0.0f, 1.0f);
+            p.Read(52);
 
             #region Eye Expressions
 
@@ -124,11 +121,11 @@ namespace ALVRModule
 
             #region Jaw Exclusive Expressions
 
-            w[JawOpen] = p[JawShapeOpen];
+            w[JawOpen] = p[JawShapeOpen] - p[MouthClose];
+
             w[JawRight] = p[JawShapeRight];
             w[JawLeft] = p[JawShapeLeft];
             w[JawForward] = p[JawShapeForward];
-            w[MouthClosed] = p[MouthClose];
 
             #endregion
 
@@ -149,10 +146,10 @@ namespace ALVRModule
             w[LipPuckerLowerRight] = p[MouthPucker];
             w[LipPuckerLowerLeft] = p[MouthPucker];
 
-            w[MouthUpperUpRight] = Math.Max(0, p[MouthUpperUpR] - p[NoseSneerR]);
-            w[MouthUpperUpLeft] = Math.Max(0, p[MouthUpperUpL] - p[NoseSneerL]);
-            w[MouthUpperDeepenRight] = Math.Max(0, p[MouthUpperUpR] - p[NoseSneerR]);
-            w[MouthUpperDeepenLeft] = Math.Max(0, p[MouthUpperUpL] - p[NoseSneerL]);
+            w[MouthUpperUpRight] = p[MouthUpperUpR];
+            w[MouthUpperUpLeft] = p[MouthUpperUpL];
+            w[MouthUpperDeepenRight] = p[MouthUpperUpR];
+            w[MouthUpperDeepenLeft] = p[MouthUpperUpL];
 
             w[NoseSneerRight] = p[NoseSneerR];
             w[NoseSneerLeft] = p[NoseSneerL];


### PR DESCRIPTION
This PR is a part of https://github.com/alvr-org/ALVR/pull/3349.

## Summary
This PR seperates the face and eye data into the `FacePhnx` and `EyesPhnx` prefix and adds support for Phoenix eye data.

Because eye dilation isn't valid beyond a certain eye openness, it is paused when below `0.8f` to prevent the eyes constricting and dilating when blinking.

## Changes
- Add `FacePhnx` and `EyesPhnx` prefixes.
- When an exception occurs on the socket, make the thread sleep instead of loop over the exception.
- Allow float param index to be an integer too instead of an enum only.
- Add support for Phoenix eye tracking.
- Slight re-mapping of face params.